### PR TITLE
[hotfix][bug] Fix flaky test in InitTaskManagerDecoratorTest

### DIFF
--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dspotless.check.skip=true -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test with NonDex
-        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dspotless.check.skip=true -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dspotless.check.skip=true -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Build
         run: mvn clean install -Dspotless.check.skip=true -DskipTests -Dcheckstyle.skip -pl flink-kubernetes -am
       - name: Test without NonDex
-        run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+        run: mvn -pl flink-kubernetes test -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test with NonDex
-        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+      - name: Build
+        run: mvn clean install -Dspotless.check.skip=true -DskipTests -pl flink-kubernetes -am
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test without NonDex

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Build
-        run: mvn clean install -Dspotless.check.skip=true -DskipTests -pl flink-kubernetes -am
+        run: mvn clean install -Dspotless.check.skip=true -DskipTests -Dcheckstyle.skip -pl flink-kubernetes -am
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test with NonDex

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -14,8 +14,8 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Build
-        run: mvn clean install -Dspotless.check.skip=true -DskipTests -Dcheckstyle.skip -pl flink-kubernetes -am
+        run: mvn clean install -Dspotless.check.skip=true -DskipTests -pl flink-kubernetes -am
       - name: Test without NonDex
-        run: mvn -pl flink-kubernetes test -Dspotless.check.skip=true -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+        run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test with NonDex
-        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dspotless.check.skip=true -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=20 -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
+          distribution: 'temurin'
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test without NonDex

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -1,0 +1,19 @@
+name: Flaky Test Workflow
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Test without NonDex
+        run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+      - name: Test without NonDex
+        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -8,11 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: '11'
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test without NonDex

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Build
         run: mvn clean install -Dspotless.check.skip=true -DskipTests -Dcheckstyle.skip -pl flink-kubernetes -am
       - name: Test without NonDex
-        run: mvn -pl flink-kubernetes test -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+        run: mvn -pl flink-kubernetes test -Dspotless.check.skip=true -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test with NonDex
-        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
+        run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dspotless.check.skip=true -Dcheckstyle.skip -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Build
-        run: mvn clean install -Dspotless.check.skip=true -DskipTests -pl flink-kubernetes -am
+        run: mvn clean install -pl flink-kubernetes -am
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test with NonDex

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Build
-        run: mvn clean install -pl flink-kubernetes -am
+        run: mvn clean install -DskipTests -pl flink-kubernetes -am
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
       - name: Test with NonDex

--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -17,5 +17,5 @@ jobs:
         run: mvn clean install -Dspotless.check.skip=true -DskipTests -pl flink-kubernetes -am
       - name: Test without NonDex
         run: mvn -pl flink-kubernetes test -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity
-      - name: Test without NonDex
+      - name: Test with NonDex
         run: mvn -pl flink-kubernetes edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -137,8 +137,7 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
     }
 
     private NodeAffinity generateNodeAffinity(String labelKey, Set<String> blockedNodes) {
-        List<String> blockedNodesList = 
-                new ArrayList<>(blockedNodes);
+        List<String> blockedNodesList = new ArrayList<>(blockedNodes);
         Collections.sort(blockedNodesList);
 
         NodeSelectorRequirement nodeSelectorRequirement =

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -137,8 +137,12 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
     }
 
     private NodeAffinity generateNodeAffinity(String labelKey, Set<String> blockedNodes) {
+        List<String> blockedNodesList = 
+                new ArrayList<>(blockedNodes);
+        Collections.sort(blockedNodesList);
+
         NodeSelectorRequirement nodeSelectorRequirement =
-                new NodeSelectorRequirement(labelKey, "NotIn", new ArrayList<>(blockedNodes));
+                new NodeSelectorRequirement(labelKey, "NotIn", blockedNodesList);
 
         NodeAffinityBuilder nodeAffinityBuilder = new NodeAffinityBuilder();
         return nodeAffinityBuilder

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -272,8 +272,7 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
 
     @Test
     void testNodeAffinity() {
-        List<String> blockedNodesList = 
-            new ArrayList<>(BLOCKED_NODES);
+        List<String> blockedNodesList = new ArrayList<>(BLOCKED_NODES);
         Collections.sort(blockedNodesList);
 
         List<NodeSelectorTerm> nodeSelectorTerms =

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -272,6 +272,10 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
 
     @Test
     void testNodeAffinity() {
+        List<String> blockedNodesList = 
+            new ArrayList<>(BLOCKED_NODES);
+        Collections.sort(blockedNodesList);
+
         List<NodeSelectorTerm> nodeSelectorTerms =
                 this.resultPod
                         .getSpec()
@@ -288,6 +292,6 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
                                 flinkConfig.getString(
                                         KubernetesConfigOptions.KUBERNETES_NODE_NAME_LABEL),
                                 "NotIn",
-                                new ArrayList<>(BLOCKED_NODES)));
+                                blockedNodesList));
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Note: There did not appear to be an existing JIRA issue for this, but it's also not just documentation, so I labelled it as a hotfix/bug

This pull request is to fix a flaky test in the InitTaskManagerDecoratorTest class.
Module: flink-kubernetes
Test: org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecoratorTest#testNodeAffinity

It appears when testing the equality of two NodeSelectorRequirement objects, the original unit test (testNodeAffinity) would occasionally fail because the ordering of the node lists between the two objects would be different.
In the generateNodeAffinity method of InitTaskManagerDecorator class, a new ArrayList is created with the blockedNodes parameter. However, since the parameter is a Set, the ordering of the elements is not guaranteed, therefore the ordering of the elements in the new ArrayList is not guaranteed either. As a fix I added a line to sort the new ArrayList before passing it into the NodeSelectorRequirement constructor

## Brief change log

  - *Modified two lines in the generateNodeAffinity method of the InitTaskManagerDecorator class. Originally a new ArrayList was passed directly into the NodeSelectorRequirement constructor, my change creates a local variable for the new ArrayList and then sorts it before passing it into the NodeSeelctorRequirement constructor*
  - *Modified two lines in the testNodeAffinity test of the InitTaskManagerDecoratorTest class. This change was similar to the one above where instead of passing in a new ArrayList with BLOCKED_NODES directly into the NodeSelectorRequirement constructor, I create a local variable for the new ArrayList, sort it, and then pass it in*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing


This change is already covered by an existing test: testNodeAffinity (package org.apache.flink.kubernetes.kubeclient.decorators).
Style checks pass with tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
